### PR TITLE
Fix travis builds and failing specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
   - 2.1.2
   - 2.2.3
   - 2.3.0
+
+before_install:
+  - gem update bundler

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+
+task :default => :spec
+RSpec::Core::RakeTask.new

--- a/lib/uploadcare/api/group_list_api.rb
+++ b/lib/uploadcare/api/group_list_api.rb
@@ -1,7 +1,7 @@
 module Uploadcare
   module GroupListApi
     def group_list from=nil, limit=nil
-      data = get '/groups/', {from: from, limit: limit}
+      data = get '/groups/', {from: from, limit: limit}.reject{|_,v| v.nil?}
       list = Uploadcare::Api::GroupList.new self, data
     end
   end

--- a/uploadcare-ruby.gemspec
+++ b/uploadcare-ruby.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'mime-types'
 
   gem.add_development_dependency 'rspec', "~> 3"
+  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'pry'
 end


### PR DESCRIPTION
1. Old version of bundler caused `NoMethodError: undefined method 'spec' for nil:NilClass` error while performing `bundle install`
2. Rake was not listed in gem dependencies which caused `rake is not part of the bundle` error
3. Specs from spec/resources/group_list_spec.rb were failing because `get '/groups/', {from: from, limit: limit}` formed wrong request url when `form` and `limit` were both `nil`, which caused 400 BadRequest error
4. Spec at /spec/resources/file_spec.rb:105 was failing time to time because sometimes it tried to copy a file before it was ready on the server, which caused 400 BadRequest error